### PR TITLE
이메일 인증 재전송_프론트

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,23 @@
-<h2>Resend confirmation instructions</h2>
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-4">
+            <h2 class="text-center mb-4" style="font-size: 36px;"><strong>인증 이메일 전송</strong></h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+            <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+                <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-  </div>
+                <div class="mb-3 mt-3">
+                    <%= f.label :email, "이메일", class: "form-label", style: "font-size: 18px; font-weight: bold;" %>
+                    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "form-control", placeholder: "이메일을 입력하세요" %>
+                </div>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
+                <!-- Button Group with Resend Confirmation -->
+                <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+                    <%= f.submit "확인", class: "btn btn-primary" %>
+                </div>
+            <% end %>
 
-<%= render "devise/shared/links" %>
+            <%= render "devise/shared/links" %>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## 작업 내용
- 로그인 페이지에서 맨 끝 문구 이메일 재전송 클릭.
- /users/confirmation/new 기존 페이지에 부트스트랩 추가해서 꾸몄습니다.

## 스크린샷
- 
![image](https://github.com/user-attachments/assets/f6de645e-9e5d-441d-ab07-45e3c8975dc1)



## 리뷰 시 참고사항
- 
