### PR TITLE
메인창 카풀 만들기, 카풀 찾기 문구 중앙 정렬

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -81,8 +81,8 @@
 <div id="map" style="width:100%;height:590px;"></div>
 
 <div class="offcanvas offcanvas-bottom" tabindex="-1" id="carpoolCreate" aria-labelledby="carpoolCreateLabel" style="height: 70vh;">
-    <div class="offcanvas-header">
-        <h2 id="carpoolCreateLabel">카풀 만들기</h2>
+    <div class="offcanvas-header text-center justify-content-center">
+        <h2 id="carpoolCreateLabel" class="w-100">카풀 만들기</h2>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body">
@@ -112,8 +112,8 @@
 </div>
 
 <div class="offcanvas offcanvas-bottom" tabindex="-1" id="carpoolFind" aria-labelledby="carpoolFindLabel" style="height: 70vh;">
-    <div class="offcanvas-header">
-        <h2 id="carpoolFindLabel">카풀 찾기</h2>
+    <div class="offcanvas-header text-center justify-content-center">
+        <h2 id="carpoolFindLabel" class="w-100">카풀 찾기</h2>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body">


### PR DESCRIPTION
## 작업 내용
- 기존의 카풀 만들기 , 카풀 찾기 문구가 좌측 정렬
- 이들을 좌측 정렬에서 중앙 정렬로 수정했습니다.

## 스크린샷
![image](https://github.com/user-attachments/assets/d51a64bf-3f68-4a00-9369-322bc777f6e2)
![image](https://github.com/user-attachments/assets/a37d0364-7224-4d8b-8e60-98a89f7b7ba2)



## 리뷰 시 참고사항
- 
![image](https://github.com/user-attachments/assets/422f8417-df9d-4eaa-9f8f-f06ed2841a8b)
-
![image](https://github.com/user-attachments/assets/4de5073c-76a0-4a47-a251-9fcd16481d76)

여기는 기존 페이지입니다.
