### PR TITLE
카풀제목글자->사진, 지도 높이 증가, 메뉴창 중앙정렬

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -1,4 +1,12 @@
 <style>
+    html, body {
+        height: 100%;
+    }
+
+.min-100 {
+    min-height: 100vh;
+}
+
     /* Overlay */
     .overlay {
         position: fixed;
@@ -82,9 +90,7 @@
         <% end %>
     </div>
 </div>
-
-<div id="map" style="width:100%;height:85vh;"></div>
-
+<div class="row flex-fill" id="map"></div>
 <div class="offcanvas offcanvas-bottom" tabindex="-1" id="carpoolCreate" aria-labelledby="carpoolCreateLabel" style="height: 70vh;">
     <div class="offcanvas-header text-center justify-content-center">
         <h2 id="carpoolCreateLabel" class="w-100">카풀 만들기</h2>

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -3,9 +3,9 @@
         height: 100%;
     }
 
-.min-100 {
-    min-height: 100vh;
-}
+    .min-100 {
+        min-height: 100vh;
+    }
 
     /* Overlay */
     .overlay {

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -30,25 +30,30 @@
     }
 </style>
 
-<header class="bg-primary text-white text-center py-3">
-    <h1>Carpool</h1>
+<header style="background-color: #f5f5f5;" class="text-center py-3">
+    <div class="d-flex align-items-center justify-content-center">
+        <%= image_tag "carpool.png", alt: "Carpool", class: "me-3", style: "height: 90px;" %>
+    </div>
+    
     <!-- Navigation Bar -->
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <div class="container-fluid">
-            <a class="navbar-brand" href="<%= root_path %>">홈</a>
+        <div class="container-fluid d-flex justify-content-center">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <div class="collapse navbar-collapse" id="navbarNav">
+            <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
                 <ul class="navbar-nav">
-                    <li class="nav-item">
-                        <a class="nav-link offcanvas-trigger" href="#carpoolCreate">카풀 만들기</a>
+                    <li class="nav-item" style="margin: 0 15px;">
+                        <a class="nav-link" href="<%= root_path %>" style="font-size: 1.2rem;"><strong>홈</strong></a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link offcanvas-trigger" href="#carpoolFind">카풀 찾기</a>
+                    <li class="nav-item" style="margin: 0 15px;">
+                        <a class="nav-link offcanvas-trigger" href="#carpoolCreate" style="font-size: 1.2rem;"><strong>카풀 만들기</strong></a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link offcanvas-trigger" id="myInfoButton" href="#MyInfo" role="button">내 정보</a>
+                    <li class="nav-item" style="margin: 0 15px;">
+                        <a class="nav-link offcanvas-trigger" href="#carpoolFind" style="font-size: 1.2rem;"><strong>카풀 찾기</strong></a>
+                    </li>
+                    <li class="nav-item" style="margin: 0 15px;">
+                        <a class="nav-link offcanvas-trigger" id="myInfoButton" href="#MyInfo" role="button" style="font-size: 1.2rem;"><strong>내 정보</strong></a>
                     </li>
                 </ul>
             </div>
@@ -78,7 +83,7 @@
     </div>
 </div>
 
-<div id="map" style="width:100%;height:590px;"></div>
+<div id="map" style="width:100%;height:85vh;"></div>
 
 <div class="offcanvas offcanvas-bottom" tabindex="-1" id="carpoolCreate" aria-labelledby="carpoolCreateLabel" style="height: 70vh;">
     <div class="offcanvas-header text-center justify-content-center">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,10 @@
         })
         </script>
     <% end %>
-    <%= yield %>  <!-- Bootstrap JS (Optional) -->
+    <div class="container-fluid min-100 d-flex flex-column">
+      <%= yield %>
+    </div>
+    <!-- Bootstrap JS (Optional) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
## 작업 내용
- 카풀 제목 수정(Carpool->사진)
- 지도 높이 증가(데스크탑 기준, 혹시 짤리면 알려주세요!!)
- 메뉴 창 중앙 정렬(이 때, 홈도 목록에 넣었습니다!!!)

## 스크린샷
- 
![image](https://github.com/user-attachments/assets/99fb2303-c4d7-4720-a4b0-efa70f4eb993)
![image](https://github.com/user-attachments/assets/724683ae-aa47-4b65-bae4-401c1018605b)
수정본



## 리뷰 시 참고사항
- 1번째 사진은 전체 화면, 2번째 사진은 부분적 화면
- 
![image](https://github.com/user-attachments/assets/076d3369-181c-45c2-a822-9718138dc0be)
![image](https://github.com/user-attachments/assets/f13c0e2a-e3db-4ec5-b692-fa8021e723de)
이 사진들은 기존 페이지입니다.
