### PR TITLE
회원가입 두껍게, 확인 이메일 재전송 창 문구변경

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -279,28 +279,4 @@
             }
         );
     }
-
-//로그인후 뒤로가기 x 오작동 이슈 해결?(이게 맞나?) 
-    document.addEventListener('DOMContentLoaded', function () {
-    const myInfoOffcanvas = document.getElementById('MyInfo');
-    const myInfoInstance = bootstrap.Offcanvas.getOrCreateInstance(myInfoOffcanvas);
-
-    // 뒤로가기 시 오프캔버스 상태를 닫고 페이지를 새로고침
-    window.addEventListener('popstate', function () {
-        if (myInfoInstance && myInfoInstance._isShown) {
-            myInfoInstance.hide(); // 오프캔버스가 열린 상태라면 닫기
-        }
-        location.reload(); // 페이지 새로고침으로 강제 초기화
-    });
-
-    // 로그인 버튼 클릭 시 히스토리 추가
-    const loginButton = document.querySelector('.btn-primary'); // 로그인 버튼 선택자에 맞게 조정 필요
-    if (loginButton) {
-        loginButton.addEventListener('click', function () {
-            history.pushState(null, null, location.href);
-        });
-    }
-});
-
-
 </script>

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -279,4 +279,28 @@
             }
         );
     }
+
+//로그인후 뒤로가기 x 오작동 이슈 해결?(이게 맞나?) 
+    document.addEventListener('DOMContentLoaded', function () {
+    const myInfoOffcanvas = document.getElementById('MyInfo');
+    const myInfoInstance = bootstrap.Offcanvas.getOrCreateInstance(myInfoOffcanvas);
+
+    // 뒤로가기 시 오프캔버스 상태를 닫고 페이지를 새로고침
+    window.addEventListener('popstate', function () {
+        if (myInfoInstance && myInfoInstance._isShown) {
+            myInfoInstance.hide(); // 오프캔버스가 열린 상태라면 닫기
+        }
+        location.reload(); // 페이지 새로고침으로 강제 초기화
+    });
+
+    // 로그인 버튼 클릭 시 히스토리 추가
+    const loginButton = document.querySelector('.btn-primary'); // 로그인 버튼 선택자에 맞게 조정 필요
+    if (loginButton) {
+        loginButton.addEventListener('click', function () {
+            history.pushState(null, null, location.href);
+        });
+    }
+});
+
+
 </script>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container mt-5">
     <img src="<%= asset_path("carpool.png") %>" alt="logo" class="d-block mx-auto mb-4" style="width: 300px; height: auto;">
-    <p class="text-center mt-3 lead fw-bold">이메일을 받지 못하셨나요? 지금 다시 보내드립니다.</p>
+    <p class="text-center mt-3 lead fw-bold">인증 이메일을 받지 못하셨나요?</p>
 
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'mt-4' }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,23 +1,16 @@
 <div class="container mt-5">
-    <div class="row justify-content-center">
-        <div class="col-md-4">
-            <h2 class="text-center mb-4" style="font-size: 36px;"><strong>인증 이메일 전송</strong></h2>
+    <img src="<%= asset_path("carpool.png") %>" alt="logo" class="d-block mx-auto mb-4" style="width: 300px; height: auto;">
+    <p class="text-center mt-3 lead fw-bold">이메일을 받지 못하셨나요? 지금 다시 보내드립니다.</p>
 
-            <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-                <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'mt-4' }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-                <div class="mb-3 mt-3">
-                    <%= f.label :email, "이메일", class: "form-label", style: "font-size: 18px; font-weight: bold;" %>
-                    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "form-control", placeholder: "이메일을 입력하세요" %>
-                </div>
-
-                <!-- Button Group with Resend Confirmation -->
-                <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-                    <%= f.submit "확인", class: "btn btn-primary" %>
-                </div>
-            <% end %>
-
-            <%= render "devise/shared/links" %>
+        <div class="mx-auto" style="max-width: 460px;">
+            <div class="mb-3">
+                <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "form-control", placeholder: "이메일을 입력하세요" %>
+            </div>
+            <%= f.submit "확인", class: "btn btn-primary w-100" %>
         </div>
-    </div>
+    <% end %>
+    <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,20 +1,24 @@
 <div class="container mt-5">
     <div class="row justify-content-center">
         <div class="col-md-4">
-            <h2 class="text-center" style="font-size: 36px;"><strong>회원가입</strong></h2>
-            
+            <h2 class="text-center" style="font-size: 36px;">회원가입</h2>
+            <style>
+                .new_user label {
+                    font-weight: bold;
+                }
+            </style>
             <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
                 <%= render "devise/shared/error_messages", resource: resource %>
                 <div class="mb-3">
-                    <%= f.label :email, "<strong>이메일</strong>".html_safe, class: "form-label" %>
+                    <%= f.label :email, "이메일", class: "form-label" %>
                     <%= f.text_field :email, class: "form-control", placeholder: "이메일을 입력하세요" %>
                 </div>
                 <div class="mb-3">
-                    <%= f.label :password, "<strong>비밀번호</strong>".html_safe, class: "form-label" %>
+                    <%= f.label :password, "비밀번호", class: "form-label" %>
                     <%= f.password_field :password, class: "form-control", placeholder: "비밀번호를 입력하세요" %>
                 </div>
                 <div class="mb-3">
-                    <%= f.label :password_confirmation, "<strong>비밀번호 확인</strong>".html_safe, class: "form-label" %>
+                    <%= f.label :password_confirmation, "비밀번호 확인", class: "form-label" %>
                     <%= f.password_field :password_confirmation, class: "form-control", placeholder: "비밀번호를 다시 입력하세요" %>
                 </div>
                 <!-- Button Group with Sign Up and Cancel -->

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,15 +6,15 @@
             <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
                 <%= render "devise/shared/error_messages", resource: resource %>
                 <div class="mb-3">
-                    <%= f.label :email, "이메일", class: "form-label" %>
+                    <%= f.label :email, "<strong>이메일</strong>".html_safe, class: "form-label" %>
                     <%= f.text_field :email, class: "form-control", placeholder: "이메일을 입력하세요" %>
                 </div>
                 <div class="mb-3">
-                    <%= f.label :password, "비밀번호", class: "form-label" %>
+                    <%= f.label :password, "<strong>비밀번호</strong>".html_safe, class: "form-label" %>
                     <%= f.password_field :password, class: "form-control", placeholder: "비밀번호를 입력하세요" %>
                 </div>
                 <div class="mb-3">
-                    <%= f.label :password_confirmation, "비밀번호 확인", class: "form-label" %>
+                    <%= f.label :password_confirmation, "<strong>비밀번호 확인</strong>".html_safe, class: "form-label" %>
                     <%= f.password_field :password_confirmation, class: "form-control", placeholder: "비밀번호를 다시 입력하세요" %>
                 </div>
                 <!-- Button Group with Sign Up and Cancel -->


### PR DESCRIPTION
## 작업 내용
- 확인 이메일 받기 문구수정+사진추가
- 회원가입창 문구들 진하게 수정함

## 스크린샷
- 
![image](https://github.com/user-attachments/assets/b5691479-0fe7-47a2-809f-80ea0cebf09d)
- 
![image](https://github.com/user-attachments/assets/ae1f71c4-e251-42c8-b76c-8fa1e117a9aa)



## 리뷰 시 참고사항
- 
![image](https://github.com/user-attachments/assets/481e8c78-ee63-476e-bc7f-f0782e39ff50)
-
![image](https://github.com/user-attachments/assets/6bcbcefd-d056-4770-85ac-18968f58f923)

기존 페이지 입니다.

새벽에 PR 죄송합니다..