### PR TITLE
메뉴 패딩 제거, 메뉴 버튼 상하 가운데정렬

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -46,8 +46,7 @@
     <!-- Navigation Bar -->
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid d-flex justify-content-center">
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation" 
-            style="margin-top: 0px;">
+            <button class="navbar-toggler mt-0" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse justify-content-center" id="navbarNav">

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -38,7 +38,7 @@
     }
 </style>
 
-<header style="background-color: #f5f5f5;" class="text-center py-3">
+<header style="background-color: #f5f5f5;" class="row text-center px-0 py-3">
     <div class="d-flex align-items-center justify-content-center">
         <%= image_tag "carpool.png", alt: "Carpool", class: "me-3", style: "height: 90px;" %>
     </div>
@@ -46,7 +46,8 @@
     <!-- Navigation Bar -->
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid d-flex justify-content-center">
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation" 
+            style="margin-top: 0px;">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse justify-content-center" id="navbarNav">


### PR DESCRIPTION
## 작업 내용
- 메뉴 창 영역 가로100%
- 크기 수축 시, 생기는 메뉴 버튼 상하 기준으로 중앙 위치 했습니다.

## 스크린샷
- 
![image](https://github.com/user-attachments/assets/6ca6e698-f9aa-463d-9999-3fd419edd86e)
-
![image](https://github.com/user-attachments/assets/cdd8fe89-7e92-4ea9-b787-02074da6d37b)



## 리뷰 시 참고사항
- 리뷰 검토 부탁드려요~~~!!
