### PR TITLE
없는 CSS, JS 로드하지 않도록 수정

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,9 +17,6 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
 
-    <link rel="stylesheet" href="css/style.css">
-    <!-- Bootstrap CDN -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
     <!-- Google Fonts: Roboto -->
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <meta name="description" content="Carpool system for easy ride-sharing.">


### PR DESCRIPTION
## 작업 내용
- 존재하지 않는 CSS, JS를 불러오는 코드를 제거했습니다.

## 스크린샷
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/1431b3ca-7ea5-4707-9f5a-5bb05807283e">


## 리뷰 시 참고사항
- 
