### PR TITLE
카풀만들기헬퍼수정+홈삭제+단순화

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,10 +1,3 @@
 class Place < ApplicationRecord
   enum place_type: [ :start, :end ]
-
-  # 출발지로 지정된 Place 레코드를 가져오는 경우
-  Place.start
-
-  # 목적지로 지정된 Place 레코드를 가져오는 경우
-  Place.end
-
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,2 +1,10 @@
 class Place < ApplicationRecord
+  enum place_type: [ :start, :end ]
+
+  # 출발지로 지정된 Place 레코드를 가져오는 경우
+  Place.start
+
+  # 목적지로 지정된 Place 레코드를 가져오는 경우
+  Place.end
+
 end

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -51,11 +51,6 @@
             </button>
             <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
                 <ul class="navbar-nav">
-                    <!--
-                    <li class="nav-item" style="margin: 0 15px;">
-                        <a class="nav-link" href="<%= root_path %>" style="font-size: 1.2rem;"><strong>홈</strong></a>
-                    </li>
-                    -->
                     <li class="nav-item" style="margin: 0 15px;">
                         <a class="nav-link offcanvas-trigger" href="#carpoolCreate" style="font-size: 1.2rem;"><strong>카풀 만들기</strong></a>
                     </li>
@@ -93,16 +88,15 @@
     </div>
 </div>
 
-<!--카카오 지도 API-->
 <div class="row flex-fill" id="map"></div>
 
 <div class="offcanvas offcanvas-bottom" tabindex="-1" id="carpoolCreate" aria-labelledby="carpoolCreateLabel" style="height: 70vh;">
     <div class="offcanvas-header text-center justify-content-center">
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
-    <div class="offcanvas-body" style="padding: 0">
+    <div class="offcanvas-body p-0">
         <main class="container">
-            <section class="carpool-form" id="carpoolFormSection" style="border: none; padding: 0;">
+            <section class="carpool-form p-0" id="carpoolFormSection" style="border: none;">
                 <%= form_with url: pools_path, method: :post, id: "carpoolForm", html: { class: "p-4 border rounded shadow-sm" } do |f| %>
                     <!-- 출발지 입력 -->
                     <div class="mb-3">

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -51,9 +51,11 @@
             </button>
             <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
                 <ul class="navbar-nav">
+                    <!--
                     <li class="nav-item" style="margin: 0 15px;">
                         <a class="nav-link" href="<%= root_path %>" style="font-size: 1.2rem;"><strong>홈</strong></a>
                     </li>
+                    -->
                     <li class="nav-item" style="margin: 0 15px;">
                         <a class="nav-link offcanvas-trigger" href="#carpoolCreate" style="font-size: 1.2rem;"><strong>카풀 만들기</strong></a>
                     </li>
@@ -90,48 +92,54 @@
         <% end %>
     </div>
 </div>
+
+<!--카카오 지도 API-->
 <div class="row flex-fill" id="map"></div>
+
 <div class="offcanvas offcanvas-bottom" tabindex="-1" id="carpoolCreate" aria-labelledby="carpoolCreateLabel" style="height: 70vh;">
     <div class="offcanvas-header text-center justify-content-center">
-        <h2 id="carpoolCreateLabel" class="w-100">카풀 만들기</h2>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
-    <div class="offcanvas-body">
-        <main class="container mt-5">
-            <section class="carpool-form mb-5" id="carpoolFormSection">
-                <h2 class="text-center">카풀 정보</h2>
-                <form id="carpoolForm">
+    <div class="offcanvas-body" style="padding: 0">
+        <main class="container">
+            <section class="carpool-form" id="carpoolFormSection" style="border: none; padding: 0;">
+                <%= form_with url: pools_path, method: :post, id: "carpoolForm", html: { class: "p-4 border rounded shadow-sm" } do |f| %>
+                    <!-- 출발지 입력 -->
                     <div class="mb-3">
-                        <label for="startPoint" class="form-label">출발지</label>
-                        <input type="text" id="startPoint" name="startPoint" class="form-control" required>
+                        <%= f.label :startPoint, "출발지", class: "form-label fw-bold" %>
+                        <%= f.text_field :startPoint, placeholder: "출발지를 입력하세요", class: "form-control", required: true %>
                     </div>
+                    <!-- 목적지 입력 -->
                     <div class="mb-3">
-                        <label for="endPoint" class="form-label">목적지</label>
-                        <input type="text" id="endPoint" name="endPoint" class="form-control" required>
+                        <%= f.label :endPoint, "목적지", class: "form-label fw-bold" %>
+                        <%= f.text_field :endPoint, placeholder: "목적지를 입력하세요", class: "form-control", required: true %>
                     </div>
+                    <!-- 좌석 수 입력 -->
                     <div class="mb-3">
-                        <label for="seat" class="form-label">좌석 수</label>
-                        <input type="number" id="seat" name="seat" class="form-control" min="1" max="4" placeholder="1~4까지 가능합니다." required>
+                        <%= f.label :seat, "좌석 수", class: "form-label fw-bold" %>
+                        <%= f.number_field :seat, 
+                            min: 1, max: 4, 
+                            placeholder: "1~4까지 가능합니다.", class: "form-control", required: true %>
                     </div>
-                    <div class="text-end">
-                        <button type="submit" class="btn btn-primary">확인</button>
+                    <!-- 제출 버튼 -->
+                    <div class="text-end mt-4">
+                        <%= f.submit "확인", class: "btn btn-primary px-4" %>
                     </div>
-                    </form>
-                </section>           
+                <% end %>
+            </section>           
         </main>
     </div>
 </div>
 
 <div class="offcanvas offcanvas-bottom" tabindex="-1" id="carpoolFind" aria-labelledby="carpoolFindLabel" style="height: 70vh;">
     <div class="offcanvas-header text-center justify-content-center">
-        <h2 id="carpoolFindLabel" class="w-100">카풀 찾기</h2>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body">
-        <main class="container mt-5">
+        <main class="container">
             <!-- Carpool List -->
             <section class="carpool-list" id="carpoolListSection">
-                <h2 class="text-center">목록</h2>
+                <h2 class="text-center">카풀 목록</h2>
                 <table id="carpoolTable" class="table table-striped table-bordered">
                     <thead class="table-dark">
                         <tr>


### PR DESCRIPTION
## 작업 내용
- 메인 창에서 상단 메뉴에 있는 '홈' 제거
- 카풀 만들기 html에서 레일즈 헬퍼 사용+'카풀 정보' 문구 삭제
- 카풀 찾기 클릭 후 나오는 '카풀 찾기' 문구 삭제

## 스크린샷
- 
![image](https://github.com/user-attachments/assets/adcfed41-fa48-4f9b-878e-91a70ee82e62)
- 
![image](https://github.com/user-attachments/assets/78649718-dc2e-41fe-8cd7-4da4a0076046)
-
![image](https://github.com/user-attachments/assets/c911e5de-422d-4f35-b86d-17bca613b50d)



## 리뷰 시 참고사항
- 
