### PR TITLE
admin 기본값 false로 설정

### DIFF
--- a/db/migrate/20241119070938_add_admin_default_to_users.rb
+++ b/db/migrate/20241119070938_add_admin_default_to_users.rb
@@ -1,0 +1,6 @@
+class AddAdminDefaultToUsers < ActiveRecord::Migration[7.2]
+  def change
+    # admin의 기본 값을 false로 설정
+    change_column_default :users, :admin, from: nil, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_19_055815) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_19_070938) do
   create_table "bookings", force: :cascade do |t|
     t.integer "pool_id", null: false
     t.integer "user_id", null: false
@@ -62,7 +62,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_19_055815) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "admin"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 작업 내용
- 기본 사용자의 admin 여부를 false로 설정

## 스크린샷
- 


## 리뷰 시 참고사항
- 이 PR 적용 후 서버 실행 시 PendingMigrationError 오류가 계속 나고 마이그레이션 진행이 안되면 db reset 필요
