### PR TITLE
카풀 생성자가 카풀 참가 취소 가능한 현상

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -1,7 +1,7 @@
 class PoolsController < ApplicationController
   include Pagy::Backend
   before_action :authenticate_user!, except: [ :index ]
-  before_action :set_pool, only: %i[ show edit update destroy join finish]
+  before_action :set_pool, only: %i[ show edit update destroy join cancel_join finish]
 
   # GET /pools or /pools.json
   def index
@@ -141,6 +141,22 @@ class PoolsController < ApplicationController
       else
         format.html { redirect_to @pool, alert: "참여 실패 했습니다!" }
       end
+    end
+  end
+
+  # DELETE /pools/:id/cancel_join
+  def cancel_join
+    # 방장은 참가 취소 불가
+    if @pool.owner == current_user
+      return redirect_to @pool, alert: "방장은 참가를 취소할 수 없습니다. 삭제만 가능합니다!"
+    end
+
+    booking = @pool.bookings.find_by(user: current_user)
+    if booking.present?
+      booking.destroy
+      redirect_to @pool, notice: "참가 취소 완료!"
+    else
+      redirect_to @pool, alert: "참가 기록이 없습니다."
     end
   end
 

--- a/app/views/pools/_list.html.erb
+++ b/app/views/pools/_list.html.erb
@@ -29,7 +29,11 @@
               <% if pool.end_at <= Time.current %>
                 <button class="btn btn-secondary btn-sm h-100 d-flex m-auto" disabled>마감</button>
               <% else %>
-                <%= link_to '참가하기', join_pool_path(pool), class: "btn btn-primary btn-sm" %>
+                <% if pool.bookings.where(user: current_user).any? %>
+                  <button class="btn btn-success btn-sm m-auto" disabled>참여 중</button>
+                <% else %>
+                  <%= link_to '참가하기', join_pool_path(pool), class: "btn btn-primary btn-sm" %>
+                <% end %>
               <% end %>
             </td>
           </tr>

--- a/app/views/pools/new.html.erb
+++ b/app/views/pools/new.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="text-start mt-3">
     <%= link_to "처음처럼", root_path, class: "btn btn-primary" %>
-    <%= link_to "뒤로가기", root_path, class: "btn btn-secondary" %>
+    <%= link_to "뒤로가기", pools_path, class: "btn btn-secondary" %>
   </div>
 </div>
 

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -68,7 +68,9 @@
             <tr>
               <td colspan="2" class="text-danger">
                 이미 참가하셨습니다!
-                <%= button_to "참가 취소", cancel_join_pool_path(@pool), method: :delete, data: { turbo_confirm: '정말로 참가를 취소하시겠습니까?' }, class: "btn btn-warning btn-sm w-100" %></td>
+                <% if current_user != @pool.owner %>
+                  <%= button_to "참가 취소", cancel_join_pool_path(@pool), method: :delete, data: { turbo_confirm: '정말로 참가를 취소하시겠습니까?' }, class: "btn btn-warning btn-sm w-100" %></td>
+                <% end %>
             </tr>
           <% else %>
             <tr>

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -66,7 +66,9 @@
             </tr>
           <% elsif @pool.bookings.where(user: current_user).any? %>
             <tr>
-              <td colspan="2" class="text-danger">이미 참가하셨습니다!</td>
+              <td colspan="2" class="text-danger">
+                이미 참가하셨습니다!
+                <%= button_to "참가 취소", cancel_join_pool_path(@pool), method: :delete, data: { turbo_confirm: '정말로 참가를 취소하시겠습니까?' }, class: "btn btn-warning btn-sm w-100" %></td>
             </tr>
           <% else %>
             <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     member do
       get "join"
       get "finish"
+      delete :cancel_join
     end
   end
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?


### PR DESCRIPTION
## 작업 내용
- 카풀 참여자는 참가 취소 클릭 시 참가 중 취소
- 카풀 생성자는 카풀 참가 취소 뜨지 않고 삭제로 나갈 수 있습니다.

## 스크린샷
- 
![image](https://github.com/user-attachments/assets/114104e8-388c-4ffe-a195-338b8daf1efd)
![image](https://github.com/user-attachments/assets/1da3fe72-fba1-4a82-93f5-c20dba1d2cda)
![image](https://github.com/user-attachments/assets/e764bb89-f706-4cb8-9a46-039ad62e6d62)
![image](https://github.com/user-attachments/assets/6fef1467-7d8f-4f90-a517-75f22e7f2689)



## 리뷰 시 참고사항
- fix #125
