### PR TITLE
fix: 카풀 생성자가 카풀 참가 취소 가능한 현상

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -164,8 +164,8 @@ class PoolsController < ApplicationController
     end
 
     def check_permissions
-      if action_name == "destroy" && !(current_user.admin? || @pool.user_id == current_user.id)
-        redirect_to @pool, alert: "관리자와 방장만 수행할 수 있습니다!"
+      if action_name == "destroy" && !current_user.admin?
+        redirect_to @pool, alert: "관리자 만 수행할 수 있습니다!"
       elsif !current_user.admin? && @pool.user_id != current_user.id
         redirect_to @pool, alert: "권한이 없습니다!"
       end

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -1,7 +1,7 @@
 class PoolsController < ApplicationController
   include Pagy::Backend
   before_action :authenticate_user!, except: [:index]
-  before_action :set_pool, only: %i[show edit update destroy join finish]
+  before_action :set_pool, only: %i[show edit update destroy join unjoin finish]
   before_action :check_permissions, only: %i[edit update destroy finish]
 
   # GET /pools or /pools.json
@@ -164,8 +164,8 @@ class PoolsController < ApplicationController
     end
 
     def check_permissions
-      if action_name == "destroy" && !current_user.admin?
-        redirect_to @pool, alert: "관리자만 이 작업을 수행할 수 있습니다!"
+      if action_name == "destroy" && !(current_user.admin? || @pool.user_id == current_user.id)
+        redirect_to @pool, alert: "관리자와 방장만 수행할 수 있습니다!"
       elsif !current_user.admin? && @pool.user_id != current_user.id
         redirect_to @pool, alert: "권한이 없습니다!"
       end

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -164,8 +164,8 @@ class PoolsController < ApplicationController
     end
 
     def check_permissions
-      if action_name == "destroy" && !current_user.admin?
-        redirect_to @pool, alert: "관리자 만 수행할 수 있습니다!"
+      if action_name == "destroy" && !(current_user.admin? || @pool.user_id == current_user.id)
+        redirect_to @pool, alert: "관리자와 방장 만 수행할 수 있습니다!"
       elsif !current_user.admin? && @pool.user_id != current_user.id
         redirect_to @pool, alert: "권한이 없습니다!"
       end

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -1,6 +1,6 @@
 class PoolsController < ApplicationController
   include Pagy::Backend
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [ :index ]
   before_action :set_pool, only: %i[show edit update destroy join unjoin finish]
   before_action :check_permissions, only: %i[edit update destroy finish]
 
@@ -30,7 +30,7 @@ class PoolsController < ApplicationController
   end
 
   def random_name
-    all_names = ["스폰지밥", "뚱이", "징징이", "집게사장", "다람이", "플랑크톤", "퐁퐁부인"]
+    all_names = [ "스폰지밥", "뚱이", "징징이", "집게사장", "다람이", "플랑크톤", "퐁퐁부인" ]
     used_names = Pool.where(name: all_names).where("end_at > ?", Time.current).pluck(:name)
     available_names = all_names - used_names
 

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -64,14 +64,14 @@
             <tr>
               <td colspan="2" class="text-danger">마감되었습니다!</td>
             </tr>
-          <% elsif @pool.bookings.where(user: current_user).any? %>
+          <% elsif @pool.bookings.where(user: current_user).any? && current_user != @pool.owner %>
             <tr>
               <td colspan="2" class="text-danger">
                 <p class="lead text-bold">참가 중 입니다.</p>
                 <%= link_to '참가취소', unjoin_pool_path(@pool), class: "btn btn-danger btn-sm", data: { turbo_method: :post } %>
               </td>
             </tr>
-          <% else %>
+          <% elsif @pool.bookings.where(user: current_user).none? %>
             <tr>
               <td colspan="2">
                 <%= button_to "참가", join_pool_path(@pool), class: "btn btn-primary btn-sm w-100",data: { turbo_method: :post } %>
@@ -83,15 +83,11 @@
     </div>
     
     <div class="card-footer text-end">
-      <% if current_user == @pool.owner %>
+      <% if current_user == @pool.owner || (current_user.admin? && current_user != @pool.owner) %>
         <%= link_to '수정하기', edit_pool_path(@pool), class: "btn btn-primary btn-sm mx-2" %>
+        <%= link_to '삭제하기', @pool, data: { turbo_method: :delete, turbo_confirm: '정말 삭제하시겠습니까?' }, class: "btn btn-danger btn-sm mx-2" %>
         <%= link_to '모집 마감', finish_pool_path(@pool), class: "btn btn-success btn-sm mx-2" %>
       <% end %>
-      
-      <% if current_user.admin? %>
-        <%= link_to '삭제하기', @pool, data: { turbo_method: :delete, turbo_confirm: '정말 삭제하시겠습니까?' }, class: "btn btn-danger btn-sm mx-2" %>
-      <% end %>
-      
       <%= link_to '목록으로', pools_path, class: "btn btn-secondary btn-sm mx-2" %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     member do
       post "join"
       post "unjoin"
-      post "finish"
+      get "finish"
     end
   end
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?


### PR DESCRIPTION
## 작업 내용
- 관리자와 방장만 카풀 삭제 가능
- 기존 unjoin을 before_action에 추가

## 스크린샷

-  # 방장인 경우
![image](https://github.com/user-attachments/assets/dd75f9bb-2ac6-4404-ba26-4ab21586fcb0)
![image](https://github.com/user-attachments/assets/54809f96-dd9a-480b-a6e1-806e48b8e83d)


- # 참여자 경우
![image](https://github.com/user-attachments/assets/c9320559-c5cd-4c25-a6e9-7b26b287c1e1)
![image](https://github.com/user-attachments/assets/d727adcd-e4c6-436e-a9ec-f7da94e3403c)
![image](https://github.com/user-attachments/assets/780021e3-6b75-4ae6-9701-8332f7721df9)


- # 방장이 모집 마감 클릭
![image](https://github.com/user-attachments/assets/9f8aa77b-edf6-4581-8f48-3cca4eca98ab)



## 리뷰 시 참고 사항
- fix #125
- fix #143
- 이거 처음에는 관리자만 삭제 가능 하던데, 차라리 관리자와 방장 둘 다 삭제 가능하게 하는 방향 어떤가요?
(방장에게 관리자 권한 부여?)